### PR TITLE
feat: Xcodeプロジェクトスキャフォールド＋Appエントリポイント実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .swiftpm/
 *.o
 *.d
+.DS_Store
+*.xcuserstate
+xcuserdata/
+DerivedData/

--- a/screenshot-shitaro.xcodeproj/project.pbxproj
+++ b/screenshot-shitaro.xcodeproj/project.pbxproj
@@ -1,0 +1,580 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		0935EC212F8A14D4009C96D1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0935EC0B2F8A14D3009C96D1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0935EC122F8A14D3009C96D1;
+			remoteInfo = "screenshot-shitaro";
+		};
+		0935EC2B2F8A14D4009C96D1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0935EC0B2F8A14D3009C96D1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0935EC122F8A14D3009C96D1;
+			remoteInfo = "screenshot-shitaro";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0935EC132F8A14D3009C96D1 /* screenshot-shitaro.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "screenshot-shitaro.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0935EC202F8A14D4009C96D1 /* screenshot-shitaroTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "screenshot-shitaroTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0935EC2A2F8A14D4009C96D1 /* screenshot-shitaroUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "screenshot-shitaroUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0935EC152F8A14D3009C96D1 /* screenshot-shitaro */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "screenshot-shitaro";
+			sourceTree = "<group>";
+		};
+		0935EC232F8A14D4009C96D1 /* screenshot-shitaroTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "screenshot-shitaroTests";
+			sourceTree = "<group>";
+		};
+		0935EC2D2F8A14D4009C96D1 /* screenshot-shitaroUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "screenshot-shitaroUITests";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0935EC102F8A14D3009C96D1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0935EC1D2F8A14D4009C96D1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0935EC272F8A14D4009C96D1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0935EC0A2F8A14D3009C96D1 = {
+			isa = PBXGroup;
+			children = (
+				0935EC152F8A14D3009C96D1 /* screenshot-shitaro */,
+				0935EC232F8A14D4009C96D1 /* screenshot-shitaroTests */,
+				0935EC2D2F8A14D4009C96D1 /* screenshot-shitaroUITests */,
+				0935EC142F8A14D3009C96D1 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0935EC142F8A14D3009C96D1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0935EC132F8A14D3009C96D1 /* screenshot-shitaro.app */,
+				0935EC202F8A14D4009C96D1 /* screenshot-shitaroTests.xctest */,
+				0935EC2A2F8A14D4009C96D1 /* screenshot-shitaroUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0935EC122F8A14D3009C96D1 /* screenshot-shitaro */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0935EC342F8A14D4009C96D1 /* Build configuration list for PBXNativeTarget "screenshot-shitaro" */;
+			buildPhases = (
+				0935EC0F2F8A14D3009C96D1 /* Sources */,
+				0935EC102F8A14D3009C96D1 /* Frameworks */,
+				0935EC112F8A14D3009C96D1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				0935EC152F8A14D3009C96D1 /* screenshot-shitaro */,
+			);
+			name = "screenshot-shitaro";
+			packageProductDependencies = (
+			);
+			productName = "screenshot-shitaro";
+			productReference = 0935EC132F8A14D3009C96D1 /* screenshot-shitaro.app */;
+			productType = "com.apple.product-type.application";
+		};
+		0935EC1F2F8A14D4009C96D1 /* screenshot-shitaroTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0935EC372F8A14D4009C96D1 /* Build configuration list for PBXNativeTarget "screenshot-shitaroTests" */;
+			buildPhases = (
+				0935EC1C2F8A14D4009C96D1 /* Sources */,
+				0935EC1D2F8A14D4009C96D1 /* Frameworks */,
+				0935EC1E2F8A14D4009C96D1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0935EC222F8A14D4009C96D1 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0935EC232F8A14D4009C96D1 /* screenshot-shitaroTests */,
+			);
+			name = "screenshot-shitaroTests";
+			packageProductDependencies = (
+			);
+			productName = "screenshot-shitaroTests";
+			productReference = 0935EC202F8A14D4009C96D1 /* screenshot-shitaroTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		0935EC292F8A14D4009C96D1 /* screenshot-shitaroUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0935EC3A2F8A14D4009C96D1 /* Build configuration list for PBXNativeTarget "screenshot-shitaroUITests" */;
+			buildPhases = (
+				0935EC262F8A14D4009C96D1 /* Sources */,
+				0935EC272F8A14D4009C96D1 /* Frameworks */,
+				0935EC282F8A14D4009C96D1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0935EC2C2F8A14D4009C96D1 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0935EC2D2F8A14D4009C96D1 /* screenshot-shitaroUITests */,
+			);
+			name = "screenshot-shitaroUITests";
+			packageProductDependencies = (
+			);
+			productName = "screenshot-shitaroUITests";
+			productReference = 0935EC2A2F8A14D4009C96D1 /* screenshot-shitaroUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0935EC0B2F8A14D3009C96D1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2640;
+				LastUpgradeCheck = 2640;
+				TargetAttributes = {
+					0935EC122F8A14D3009C96D1 = {
+						CreatedOnToolsVersion = 26.4;
+					};
+					0935EC1F2F8A14D4009C96D1 = {
+						CreatedOnToolsVersion = 26.4;
+						TestTargetID = 0935EC122F8A14D3009C96D1;
+					};
+					0935EC292F8A14D4009C96D1 = {
+						CreatedOnToolsVersion = 26.4;
+						TestTargetID = 0935EC122F8A14D3009C96D1;
+					};
+				};
+			};
+			buildConfigurationList = 0935EC0E2F8A14D3009C96D1 /* Build configuration list for PBXProject "screenshot-shitaro" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0935EC0A2F8A14D3009C96D1;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 0935EC142F8A14D3009C96D1 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0935EC122F8A14D3009C96D1 /* screenshot-shitaro */,
+				0935EC1F2F8A14D4009C96D1 /* screenshot-shitaroTests */,
+				0935EC292F8A14D4009C96D1 /* screenshot-shitaroUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0935EC112F8A14D3009C96D1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0935EC1E2F8A14D4009C96D1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0935EC282F8A14D4009C96D1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0935EC0F2F8A14D3009C96D1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0935EC1C2F8A14D4009C96D1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0935EC262F8A14D4009C96D1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0935EC222F8A14D4009C96D1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0935EC122F8A14D3009C96D1 /* screenshot-shitaro */;
+			targetProxy = 0935EC212F8A14D4009C96D1 /* PBXContainerItemProxy */;
+		};
+		0935EC2C2F8A14D4009C96D1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0935EC122F8A14D3009C96D1 /* screenshot-shitaro */;
+			targetProxy = 0935EC2B2F8A14D4009C96D1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0935EC322F8A14D4009C96D1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = MXV2G82594;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		0935EC332F8A14D4009C96D1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = MXV2G82594;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		0935EC352F8A14D4009C96D1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MXV2G82594;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spleeing.screenshot-shitaro";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		0935EC362F8A14D4009C96D1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MXV2G82594;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spleeing.screenshot-shitaro";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		0935EC382F8A14D4009C96D1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MXV2G82594;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spleeing.screenshot-shitaroTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/screenshot-shitaro.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/screenshot-shitaro";
+			};
+			name = Debug;
+		};
+		0935EC392F8A14D4009C96D1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MXV2G82594;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spleeing.screenshot-shitaroTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/screenshot-shitaro.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/screenshot-shitaro";
+			};
+			name = Release;
+		};
+		0935EC3B2F8A14D4009C96D1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MXV2G82594;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spleeing.screenshot-shitaroUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = "screenshot-shitaro";
+			};
+			name = Debug;
+		};
+		0935EC3C2F8A14D4009C96D1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MXV2G82594;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.spleeing.screenshot-shitaroUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = "screenshot-shitaro";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0935EC0E2F8A14D3009C96D1 /* Build configuration list for PBXProject "screenshot-shitaro" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0935EC322F8A14D4009C96D1 /* Debug */,
+				0935EC332F8A14D4009C96D1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0935EC342F8A14D4009C96D1 /* Build configuration list for PBXNativeTarget "screenshot-shitaro" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0935EC352F8A14D4009C96D1 /* Debug */,
+				0935EC362F8A14D4009C96D1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0935EC372F8A14D4009C96D1 /* Build configuration list for PBXNativeTarget "screenshot-shitaroTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0935EC382F8A14D4009C96D1 /* Debug */,
+				0935EC392F8A14D4009C96D1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0935EC3A2F8A14D4009C96D1 /* Build configuration list for PBXNativeTarget "screenshot-shitaroUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0935EC3B2F8A14D4009C96D1 /* Debug */,
+				0935EC3C2F8A14D4009C96D1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0935EC0B2F8A14D3009C96D1 /* Project object */;
+}

--- a/screenshot-shitaro.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/screenshot-shitaro.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/screenshot-shitaro/App/screenshot_shitaroApp.swift
+++ b/screenshot-shitaro/App/screenshot_shitaroApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct ScreenshotShitaroApp: App {
+    var body: some Scene {
+        MenuBarExtra("screenshot-shitaro", systemImage: "camera.on.rectangle") {
+            MenuBarView()
+        }
+
+        Window("Editor", id: "editor") {
+            EditorView()
+        }
+    }
+}

--- a/screenshot-shitaro/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/screenshot-shitaro/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/screenshot-shitaro/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/screenshot-shitaro/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/screenshot-shitaro/Assets.xcassets/Contents.json
+++ b/screenshot-shitaro/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/screenshot-shitaro/Editor/EditorView.swift
+++ b/screenshot-shitaro/Editor/EditorView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct EditorView: View {
+    var body: some View {
+        Text("Editor")
+    }
+}

--- a/screenshot-shitaro/MenuBar/MenuBarView.swift
+++ b/screenshot-shitaro/MenuBar/MenuBarView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct MenuBarView: View {
+    var body: some View {
+        Text("screenshot-shitaro")
+    }
+}

--- a/screenshot-shitaroTests/screenshot_shitaroTests.swift
+++ b/screenshot-shitaroTests/screenshot_shitaroTests.swift
@@ -1,0 +1,19 @@
+//
+//  screenshot_shitaroTests.swift
+//  screenshot-shitaroTests
+//
+//  Created by Mitsuoka Takahiro on 2026/04/11.
+//
+
+import Testing
+@testable import screenshot_shitaro
+
+struct screenshot_shitaroTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        // Swift Testing Documentation
+        // https://developer.apple.com/documentation/testing
+    }
+
+}

--- a/screenshot-shitaroUITests/screenshot_shitaroUITests.swift
+++ b/screenshot-shitaroUITests/screenshot_shitaroUITests.swift
@@ -1,0 +1,43 @@
+//
+//  screenshot_shitaroUITests.swift
+//  screenshot-shitaroUITests
+//
+//  Created by Mitsuoka Takahiro on 2026/04/11.
+//
+
+import XCTest
+
+final class screenshot_shitaroUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // XCUIAutomation Documentation
+        // https://developer.apple.com/documentation/xcuiautomation
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/screenshot-shitaroUITests/screenshot_shitaroUITestsLaunchTests.swift
+++ b/screenshot-shitaroUITests/screenshot_shitaroUITestsLaunchTests.swift
@@ -1,0 +1,35 @@
+//
+//  screenshot_shitaroUITestsLaunchTests.swift
+//  screenshot-shitaroUITests
+//
+//  Created by Mitsuoka Takahiro on 2026/04/11.
+//
+
+import XCTest
+
+final class screenshot_shitaroUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+        // XCUIAutomation Documentation
+        // https://developer.apple.com/documentation/xcuiautomation
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## Summary

- `screenshot-shitaro.xcodeproj` を新規作成（Swift 6、macOS）
- ディレクトリ構成を整備: `App/`, `Detection/`, `Editor/`, `Annotation/`, `MenuBar/`, `Permissions/`
- `@main ScreenshotShitaroApp` に `MenuBarExtra` と `Window("Editor", id: "editor")` シーンを実装
- `INFOPLIST_KEY_LSUIElement = YES` を pbxproj に設定（Dock アイコン非表示）

## Test plan

- [x] `xcodebuild -scheme screenshot-shitaro -destination "platform=macOS"` でビルド成功確認
- [x] 生成された `Info.plist` に `LSUIElement = true` が含まれることを確認
- [x] `@main App` が `MenuBarExtra` と `Window` シーンを持つことを確認

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)