### PR TITLE
feat: スクリーンショット検知（FSEvents）＋権限チェックを実装（Issue #14）

### DIFF
--- a/screenshot-shitaro/App/screenshot_shitaroApp.swift
+++ b/screenshot-shitaro/App/screenshot_shitaroApp.swift
@@ -2,6 +2,13 @@ import SwiftUI
 
 @main
 struct ScreenshotShitaroApp: App {
+    init() {
+        // 起動時にスクリーン録画権限を確認・要求
+        PermissionChecker.shared.checkAndRequest()
+        // FSEvent 監視を開始
+        ScreenshotDetector.shared.start()
+    }
+
     var body: some Scene {
         MenuBarExtra("screenshot-shitaro", systemImage: "camera.on.rectangle") {
             MenuBarView()

--- a/screenshot-shitaro/Detection/ScreenshotDetector.swift
+++ b/screenshot-shitaro/Detection/ScreenshotDetector.swift
@@ -1,0 +1,91 @@
+import Foundation
+import CoreServices
+
+/// FSEventStream を使用して ~/Desktop の .png ファイル出現を監視するクラス。
+/// AppKit / CGEventTap は使用しない。
+@Observable
+final class ScreenshotDetector: @unchecked Sendable {
+    static let shared = ScreenshotDetector()
+
+    /// 最後に検知したスクリーンショットの URL。変化を監視して編集ウィンドウを開く。
+    private(set) var latestScreenshotURL: URL?
+
+    private var eventStream: FSEventStreamRef?
+
+    private init() {}
+
+    /// ~/Desktop の FSEvent 監視を開始する。
+    func start() {
+        guard eventStream == nil else { return }
+
+        let desktopPath = FileManager.default.homeDirectoryForCurrentUser
+            .appending(path: "Desktop", directoryHint: .isDirectory)
+            .path
+
+        // C コールバックに self を渡すための context
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        // FSEventStream コールバック（@convention(c) — nonisolated）
+        let callback: FSEventStreamCallback = { (_, contextInfo, numEvents, eventPaths, eventFlags, _) in
+            guard let contextInfo else { return }
+
+            let detector = Unmanaged<ScreenshotDetector>.fromOpaque(contextInfo)
+                .takeUnretainedValue()
+
+            // kFSEventStreamCreateFlagUseCFTypes により CFArray<CFString> として届く
+            let pathsArray = Unmanaged<CFArray>.fromOpaque(eventPaths)
+                .takeUnretainedValue() as NSArray
+
+            for index in 0..<numEvents {
+                guard let path = pathsArray[index] as? String else { continue }
+
+                let flags = eventFlags[index]
+                let isCreated = flags & UInt32(kFSEventStreamEventFlagItemCreated) != 0
+                let isFile    = flags & UInt32(kFSEventStreamEventFlagItemIsFile)    != 0
+                guard isCreated, isFile, path.hasSuffix(".png") else { continue }
+
+                // 作成時刻が直近 3 秒以内のファイルのみ対象
+                let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+                let creationDate = attrs?[.creationDate] as? Date ?? Date()
+                guard Date().timeIntervalSince(creationDate) <= 3.0 else { continue }
+
+                let url = URL(fileURLWithPath: path)
+                Task { @MainActor in
+                    detector.latestScreenshotURL = url
+                }
+            }
+        }
+
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            callback,
+            &context,
+            [desktopPath] as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.5, // latency（秒）
+            FSEventStreamCreateFlags(
+                kFSEventStreamCreateFlagFileEvents |
+                kFSEventStreamCreateFlagUseCFTypes
+            )
+        ) else { return }
+
+        FSEventStreamSetDispatchQueue(stream, DispatchQueue.main)
+        FSEventStreamStart(stream)
+        eventStream = stream
+    }
+
+    /// 監視を停止してストリームを解放する。
+    func stop() {
+        guard let stream = eventStream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+        eventStream = nil
+    }
+}

--- a/screenshot-shitaro/MenuBar/MenuBarView.swift
+++ b/screenshot-shitaro/MenuBar/MenuBarView.swift
@@ -1,7 +1,33 @@
 import SwiftUI
 
 struct MenuBarView: View {
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.openURL) private var openURL
+
+    private let detector = ScreenshotDetector.shared
+    private let permissionChecker = PermissionChecker.shared
+
     var body: some View {
         Text("screenshot-shitaro")
+            // スクリーンショット検知時に編集ウィンドウを開く
+            .onChange(of: detector.latestScreenshotURL) { _, url in
+                guard url != nil else { return }
+                openWindow(id: "editor")
+            }
+            // 権限未取得時のアラート
+            .alert("スクリーン録画の権限が必要です", isPresented: .init(
+                get: { permissionChecker.needsPermissionAlert },
+                set: { if !$0 { permissionChecker.dismissAlert() } }
+            )) {
+                Button("設定を開く") {
+                    openURL(permissionChecker.settingsURL)
+                    permissionChecker.dismissAlert()
+                }
+                Button("キャンセル", role: .cancel) {
+                    permissionChecker.dismissAlert()
+                }
+            } message: {
+                Text("スクリーンショットを自動検知するには、システム設定でスクリーン録画の権限を許可してください。")
+            }
     }
 }

--- a/screenshot-shitaro/Permissions/PermissionChecker.swift
+++ b/screenshot-shitaro/Permissions/PermissionChecker.swift
@@ -1,0 +1,36 @@
+import Foundation
+import CoreGraphics
+
+/// スクリーン録画権限を確認・要求するクラス。
+/// AppKit を使用しない（アラート表示は SwiftUI 側に委譲）。
+@Observable
+final class PermissionChecker {
+    static let shared = PermissionChecker()
+
+    /// true の場合、権限が未取得のためアラート表示が必要。
+    private(set) var needsPermissionAlert = false
+
+    /// システム設定のスクリーン録画プライバシー画面を開く URL。
+    let settingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
+
+    private init() {}
+
+    /// スクリーン録画権限を確認し、未取得の場合はシステムダイアログを要求する。
+    /// ダイアログ後も権限が取得されていない場合は `needsPermissionAlert` を true にする。
+    func checkAndRequest() {
+        guard !CGPreflightScreenCaptureAccess() else { return }
+
+        // システムダイアログを表示して権限を要求
+        CGRequestScreenCaptureAccess()
+
+        // 要求後に再確認（初回は権限が付与されない場合が多い）
+        if !CGPreflightScreenCaptureAccess() {
+            needsPermissionAlert = true
+        }
+    }
+
+    /// アラートを表示済みとしてフラグをリセットする。
+    func dismissAlert() {
+        needsPermissionAlert = false
+    }
+}


### PR DESCRIPTION
## Summary

- `Detection/ScreenshotDetector.swift`: FSEventStreamCreate で ~/Desktop を監視する `@Observable` クラスを実装。`@unchecked Sendable` で Swift 6 のアクター境界をブリッジし、`@convention(c)` コールバックから `Task { @MainActor in }` で `latestScreenshotURL` を更新
- `Permissions/PermissionChecker.swift`: `CGRequestScreenCaptureAccess()` / `CGPreflightScreenCaptureAccess()` のみ使用（AppKit 不使用）。権限未取得時に `needsPermissionAlert = true` を設定
- `App/screenshot_shitaroApp.swift`: 起動時に権限チェックと FSEvent 監視を開始
- `MenuBar/MenuBarView.swift`: `latestScreenshotURL` 変化時に `openWindow(id: "editor")` を呼び出し。権限アラートを SwiftUI `.alert` で表示し、「設定を開く」で `openURL` を使用（AppKit 不使用）

## 技術的な補足

- `FSEventStreamScheduleWithRunLoop`（deprecated in macOS 13）の代わりに `FSEventStreamSetDispatchQueue(stream, DispatchQueue.main)` を使用
- `kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagUseCFTypes` で個別ファイルイベントを CFArray<CFString> 形式で受信
- ビルド確認: Swift 6 コンパイルエラーなし (`BUILD SUCCEEDED`)

## Test plan

- [ ] `ScreenshotDetector.shared.start()` 後に ~/Desktop に .png を置くと `latestScreenshotURL` が更新されること（実機確認）
- [ ] スクリーン録画権限が未付与の場合、起動時にシステムダイアログが開くこと
- [ ] `xcodebuild -scheme screenshot-shitaro -destination "platform=macOS" build` が成功すること ✅

## 残課題・リスク

- サンドボックス (`ENABLE_APP_SANDBOX = YES`) 環境では ~/Desktop への FSEvent アクセスに追加エンタイトルメント（`com.apple.security.files.downloads.read-only` 等）が必要になる可能性がある
- 権限要求後のアプリ再起動が必要なケースでは、アラートで再起動を促す UI の追加が望ましい

Closes #14