### PR TITLE
feat: Editor UI（Canvas+DragGesture）＋AnnotationRenderer（Path描画）（Issue #16）

### DIFF
--- a/screenshot-shitaro/Editor/AnnotationRenderer.swift
+++ b/screenshot-shitaro/Editor/AnnotationRenderer.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// 純粋 Swift の描画ロジック。Path を生成する static 関数群。
+/// NSBezierPath は使用しない。
+enum AnnotationRenderer {
+
+    // MARK: - Path 生成
+
+    /// 矢印パス（atan2 で矢印頭を計算）
+    static func arrowPath(from start: CGPoint, to end: CGPoint, lineWidth: CGFloat) -> Path {
+        var path = Path()
+        guard start != end else { return path }
+
+        path.move(to: start)
+        path.addLine(to: end)
+
+        let headLength = max(lineWidth * 4, 14)
+        let angle = atan2(end.y - start.y, end.x - start.x)
+        let spread: CGFloat = .pi / 6 // 30°
+
+        let tip1 = CGPoint(
+            x: end.x - headLength * cos(angle - spread),
+            y: end.y - headLength * sin(angle - spread)
+        )
+        let tip2 = CGPoint(
+            x: end.x - headLength * cos(angle + spread),
+            y: end.y - headLength * sin(angle + spread)
+        )
+
+        path.move(to: end)
+        path.addLine(to: tip1)
+        path.move(to: end)
+        path.addLine(to: tip2)
+
+        return path
+    }
+
+    /// 矩形パス
+    static func rectPath(from start: CGPoint, to end: CGPoint) -> Path {
+        Path(normalizedRect(from: start, to: end))
+    }
+
+    /// 楕円パス
+    static func circlePath(from start: CGPoint, to end: CGPoint) -> Path {
+        Path(ellipseIn: normalizedRect(from: start, to: end))
+    }
+
+    /// 直線パス
+    static func linePath(from start: CGPoint, to end: CGPoint) -> Path {
+        var path = Path()
+        path.move(to: start)
+        path.addLine(to: end)
+        return path
+    }
+
+    /// ハイライトパス（水平方向の帯）
+    static func highlightPath(from start: CGPoint, to end: CGPoint, lineWidth: CGFloat) -> Path {
+        let rect = CGRect(
+            x: min(start.x, end.x),
+            y: min(start.y, end.y) - lineWidth / 2,
+            width: abs(end.x - start.x),
+            height: lineWidth
+        )
+        return Path(rect)
+    }
+
+    // MARK: - GraphicsContext 描画
+
+    /// Annotation を GraphicsContext に描画する。
+    /// - Parameters:
+    ///   - annotation: 描画対象
+    ///   - blurredImages: blur ツール用の事前処理済み CGImage（UUID → CGImage）
+    ///   - context: Canvas の描画コンテキスト
+    ///   - alpha: プレビュー時の透過度（デフォルト 1.0）
+    static func draw(
+        _ annotation: Annotation,
+        blurredImages: [UUID: CGImage],
+        in context: inout GraphicsContext,
+        alpha: Double = 1.0
+    ) {
+        let color = annotation.color.opacity(alpha)
+
+        switch annotation.tool {
+        case .arrow:
+            let path = arrowPath(from: annotation.start, to: annotation.end, lineWidth: annotation.lineWidth)
+            context.stroke(path, with: .color(color), lineWidth: annotation.lineWidth)
+
+        case .rect:
+            let path = rectPath(from: annotation.start, to: annotation.end)
+            context.stroke(path, with: .color(color), lineWidth: annotation.lineWidth)
+
+        case .circle:
+            let path = circlePath(from: annotation.start, to: annotation.end)
+            context.stroke(path, with: .color(color), lineWidth: annotation.lineWidth)
+
+        case .line:
+            let path = linePath(from: annotation.start, to: annotation.end)
+            context.stroke(path, with: .color(color), lineWidth: annotation.lineWidth)
+
+        case .highlight:
+            let path = highlightPath(from: annotation.start, to: annotation.end, lineWidth: annotation.lineWidth * 8)
+            context.fill(path, with: .color(annotation.color.opacity(0.35 * alpha)))
+
+        case .text:
+            if let text = annotation.text, !text.isEmpty {
+                context.draw(
+                    Text(text)
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(color),
+                    at: annotation.start,
+                    anchor: .topLeading
+                )
+            }
+
+        case .blur:
+            guard let rect = annotation.blurRect else { return }
+            if let cgImg = blurredImages[annotation.id] {
+                let resolved = context.resolve(Image(decorative: cgImg, scale: 1.0))
+                context.draw(resolved, in: rect)
+            } else {
+                // ドラッグ中 / 処理待ち: プレースホルダー矩形
+                context.fill(Path(rect), with: .color(Color.accentColor.opacity(0.12 * alpha)))
+                context.stroke(
+                    Path(rect),
+                    with: .color(Color.accentColor.opacity(0.7 * alpha)),
+                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
+                )
+            }
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private static func normalizedRect(from start: CGPoint, to end: CGPoint) -> CGRect {
+        CGRect(
+            x: min(start.x, end.x),
+            y: min(start.y, end.y),
+            width: abs(end.x - start.x),
+            height: abs(end.y - start.y)
+        )
+    }
+}

--- a/screenshot-shitaro/Editor/EditorView.swift
+++ b/screenshot-shitaro/Editor/EditorView.swift
@@ -1,7 +1,258 @@
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct EditorView: View {
+    @Environment(\.undoManager) private var undoManager
+
+    @State private var store = AnnotationStore()
+    @State private var previewAnnotation: Annotation?
+    @State private var canvasSize: CGSize = CGSize(width: 800, height: 600)
+
+    // テキストツール
+    @State private var textInputPosition: CGPoint?
+    @State private var textInput = ""
+
+    // blur ツール: 事前処理済み CGImage
+    @State private var blurredImages: [UUID: CGImage] = [:]
+
+    // ソース画像（Issue #14 マージ後に ScreenshotDetector から注入予定）
+    @State private var sourceImage: NSImage?
+
     var body: some View {
-        Text("Editor")
+        VStack(spacing: 0) {
+            ToolbarView(store: store) {
+                undoManager?.undo()
+            } onRedo: {
+                undoManager?.redo()
+            }
+
+            Divider()
+
+            canvasArea
+        }
+        .frame(minWidth: 640, minHeight: 480)
+        // ⌘+C / ⌘+S は非表示ボタン経由でウィンドウ全体に効かせる
+        .background(keyboardShortcutButtons)
+        .onAppear {
+            // AppKit 使用: floating ウィンドウ設定（1行のみ）
+            NSApp.windows.first { $0.title == "Editor" }?.level = .floating
+        }
+    }
+
+    // MARK: - Canvas エリア
+
+    @ViewBuilder
+    private var canvasArea: some View {
+        ZStack {
+            // 背景：ソース画像またはプレースホルダー
+            Group {
+                if let img = sourceImage {
+                    Image(nsImage: img)
+                        .resizable()
+                        .scaledToFit()
+                } else {
+                    Color(white: 0.14)
+                        .overlay {
+                            Text("スクリーンショットを取得してください")
+                                .foregroundStyle(.secondary)
+                        }
+                }
+            }
+
+            // アノテーション Canvas
+            let annotations = store.annotations
+            let preview = previewAnnotation
+            let blurImgs = blurredImages
+
+            Canvas { context, size in
+                for annotation in annotations {
+                    AnnotationRenderer.draw(annotation, blurredImages: blurImgs, in: &context)
+                }
+                if let p = preview {
+                    AnnotationRenderer.draw(p, blurredImages: [:], in: &context, alpha: 0.6)
+                }
+            }
+            .gesture(dragGesture)
+            .background {
+                GeometryReader { geo in
+                    Color.clear
+                        .onAppear { canvasSize = geo.size }
+                        .onChange(of: geo.size) { _, s in canvasSize = s }
+                }
+            }
+
+            // テキスト入力オーバーレイ
+            if let pos = textInputPosition {
+                TextField("テキスト入力", text: $textInput)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(store.strokeColor)
+                    .frame(minWidth: 140)
+                    .padding(4)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
+                    .position(pos)
+                    .onSubmit { commitText(at: pos) }
+            }
+        }
+    }
+
+    // MARK: - DragGesture
+
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 0, coordinateSpace: .local)
+            .onChanged { value in
+                let start = value.startLocation
+                let current = value.location
+                // 最小移動量以下はプレビューをまだ出さない
+                let moved = hypot(value.translation.width, value.translation.height)
+                guard moved > 2 || store.currentTool == .text else { return }
+                previewAnnotation = buildAnnotation(start: start, end: current)
+            }
+            .onEnded { value in
+                previewAnnotation = nil
+                let annotation = buildAnnotation(start: value.startLocation, end: value.location)
+
+                switch store.currentTool {
+                case .text:
+                    textInput = ""
+                    textInputPosition = value.startLocation
+                case .blur:
+                    store.add(annotation, undoManager: undoManager)
+                    Task {
+                        await applyBlur(for: annotation)
+                    }
+                default:
+                    store.add(annotation, undoManager: undoManager)
+                }
+            }
+    }
+
+    private func buildAnnotation(start: CGPoint, end: CGPoint) -> Annotation {
+        let blurRect: CGRect? = store.currentTool == .blur
+            ? CGRect(
+                x: min(start.x, end.x), y: min(start.y, end.y),
+                width: abs(end.x - start.x), height: abs(end.y - start.y)
+              )
+            : nil
+
+        return Annotation(
+            id: UUID(),
+            tool: store.currentTool,
+            start: start,
+            end: end,
+            color: store.strokeColor,
+            lineWidth: store.lineWidth,
+            text: nil,
+            blurRect: blurRect
+        )
+    }
+
+    // MARK: - テキスト確定
+
+    private func commitText(at pos: CGPoint) {
+        guard !textInput.isEmpty else {
+            textInputPosition = nil
+            return
+        }
+        let annotation = Annotation(
+            id: UUID(),
+            tool: .text,
+            start: pos,
+            end: pos,
+            color: store.strokeColor,
+            lineWidth: store.lineWidth,
+            text: textInput,
+            blurRect: nil
+        )
+        store.add(annotation, undoManager: undoManager)
+        textInput = ""
+        textInputPosition = nil
+    }
+
+    // MARK: - Blur 処理（async - Task 内から呼ぶ）
+
+    @MainActor
+    private func applyBlur(for annotation: Annotation) async {
+        guard let rect = annotation.blurRect,
+              let nsImg = sourceImage,
+              let cgImage = nsImg.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        else { return }
+
+        if let blurred = await BlurProcessor.shared.blur(image: cgImage, rect: rect) {
+            blurredImages[annotation.id] = blurred
+        }
+    }
+
+    // MARK: - エクスポート
+
+    private func renderToImage() -> NSImage? {
+        let size = canvasSize
+        let annotations = store.annotations
+        let blurImgs = blurredImages
+        let srcImg = sourceImage
+
+        let view = ZStack {
+            if let img = srcImg {
+                Image(nsImage: img)
+                    .resizable()
+                    .frame(width: size.width, height: size.height)
+            } else {
+                Color(white: 0.14)
+                    .frame(width: size.width, height: size.height)
+            }
+            Canvas { context, _ in
+                for annotation in annotations {
+                    AnnotationRenderer.draw(annotation, blurredImages: blurImgs, in: &context)
+                }
+            }
+            .frame(width: size.width, height: size.height)
+        }
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2.0
+        return renderer.nsImage
+    }
+
+    // MARK: - ⌘+C (BUG-3: コピー後はウィンドウを閉じない)
+
+    private func handleCopy() {
+        guard let image = renderToImage() else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.writeObjects([image])
+        // ウィンドウは維持（BUG-3 対応 — close() は呼ばない）
+    }
+
+    // MARK: - ⌘+S
+
+    private func handleSave() {
+        guard let image = renderToImage(),
+              let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:])
+        else { return }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType.png]
+        panel.nameFieldStringValue = "screenshot.png"
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            try? pngData.write(to: url)
+        }
+    }
+
+    // MARK: - キーボードショートカット（非表示ボタン）
+
+    private var keyboardShortcutButtons: some View {
+        ZStack {
+            Button("copy") { handleCopy() }
+                .keyboardShortcut("c", modifiers: .command)
+                .opacity(0)
+                .frame(width: 0, height: 0)
+            Button("save") { handleSave() }
+                .keyboardShortcut("s", modifiers: .command)
+                .opacity(0)
+                .frame(width: 0, height: 0)
+        }
     }
 }

--- a/screenshot-shitaro/Editor/ToolbarView.swift
+++ b/screenshot-shitaro/Editor/ToolbarView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct ToolbarView: View {
+    @Bindable var store: AnnotationStore
+    var onUndo: () -> Void
+    var onRedo: () -> Void
+
+    private let tools: [(AnnotationTool, String, String)] = [
+        (.arrow,     "矢印",     "arrow.up.right"),
+        (.rect,      "矩形",     "rectangle"),
+        (.circle,    "円",       "circle"),
+        (.line,      "直線",     "line.diagonal"),
+        (.text,      "テキスト", "textformat"),
+        (.blur,      "ぼかし",   "drop.degreesign"),
+        (.highlight, "ハイライト","highlighter"),
+    ]
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // ツール選択
+            ForEach(tools, id: \.0) { tool, label, icon in
+                Button {
+                    store.currentTool = tool
+                } label: {
+                    VStack(spacing: 2) {
+                        Image(systemName: icon)
+                            .font(.system(size: 14))
+                        Text(label)
+                            .font(.system(size: 9))
+                    }
+                    .frame(width: 48, height: 40)
+                }
+                .buttonStyle(.bordered)
+                .tint(store.currentTool == tool ? .accentColor : nil)
+                .help(label)
+            }
+
+            Divider().frame(height: 36)
+
+            // カラーピッカー
+            ColorPicker("", selection: $store.strokeColor, supportsOpacity: false)
+                .frame(width: 36)
+                .help("色")
+
+            // 線幅スライダー
+            HStack(spacing: 4) {
+                Image(systemName: "line.diagonal")
+                    .font(.system(size: 10))
+                Slider(value: $store.lineWidth, in: 1...20, step: 1)
+                    .frame(width: 80)
+                Text("\(Int(store.lineWidth))pt")
+                    .font(.system(size: 11))
+                    .monospacedDigit()
+                    .frame(width: 28, alignment: .trailing)
+            }
+
+            Divider().frame(height: 36)
+
+            // Undo / Redo
+            Button {
+                onUndo()
+            } label: {
+                Image(systemName: "arrow.uturn.backward")
+            }
+            .help("元に戻す (⌘Z)")
+            .keyboardShortcut("z", modifiers: .command)
+
+            Button {
+                onRedo()
+            } label: {
+                Image(systemName: "arrow.uturn.forward")
+            }
+            .help("やり直す (⌘⇧Z)")
+            .keyboardShortcut("z", modifiers: [.command, .shift])
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+}


### PR DESCRIPTION
## Summary

- **AnnotationRenderer.swift** — 純粋 Swift の Path 生成 static 関数群 + GraphicsContext 描画
  - `arrowPath(from:to:lineWidth:)` — atan2 で矢印頭を計算
  - `rectPath` / `circlePath` / `linePath` / `highlightPath` — 指定どおりのシグネチャ
  - `draw(_:blurredImages:in:alpha:)` — Canvas 描画ロジックを一箇所に集約
- **EditorView.swift** — SwiftUI Canvas + DragGesture
  - `@Environment(\.undoManager)` による undo/redo
  - `DragGesture(minimumDistance: 0, coordinateSpace: .local)` でプレビュー付き描画
  - blur ツール: `Task { await BlurProcessor.shared.blur(...) }` で非同期処理（要件通り）
  - text ツール: `TextField` overlay → `onSubmit` で `GraphicsContext.draw(_:at:)`
  - `onAppear`: `NSApp.windows.first { $0.title == "Editor" }?.level = .floating`（AppKit 1行のみ）
  - **⌘+C（BUG-3 対応）**: `NSPasteboard` にコピー後 `close()` は呼ばずウィンドウ維持
  - **⌘+S**: `NSSavePanel` → PNG 書き込み（保存成功時のみ）
  - `ImageRenderer(scale: 2.0)` で Retina 対応エクスポート
- **ToolbarView.swift** — `@Bindable AnnotationStore`
  - 7 ツールボタン、`ColorPicker`、`Slider`（1〜20pt）、undo/redo ボタン
  - `⌘Z` / `⌘⇧Z` キーボードショートカット

## Test plan

- [ ] 7 ツール全てで Canvas に描画できること（矢印は正しい方向）
- [ ] DragGesture プレビューが滑らかに更新されること
- [ ] undo/redo が `@Environment(\.undoManager)` で動作すること
- [ ] ⌘+C でクリップボードに PNG が入ること（ウィンドウが閉じないこと: BUG-3）
- [ ] ⌘+S で保存ダイアログが開きファイルが保存されること
- [ ] blur ツール: ドラッグ中はプレースホルダー矩形、確定後はぼかし適用されること
- [ ] Swift 6 コンパイルエラーなし ✅（BUILD SUCCEEDED 確認済み）

## 残課題・リスク

- `sourceImage` は現在 `nil`（Issue #14 の `ScreenshotDetector` が main にマージされたら、App エントリポイントで `latestScreenshotURL` を EditorView に渡す統合作業が必要）
- blur ツールは sourceImage が nil の間は CGImage が得られないためプレースホルダーのみ表示される（仕様上 acceptable）

🤖 Generated with [Claude Code](https://claude.com/claude-code)