### PR TITLE
feat: App統合 — ScreenshotDetector → EditorView データ接続

### DIFF
--- a/screenshot-shitaro/App/screenshot_shitaroApp.swift
+++ b/screenshot-shitaro/App/screenshot_shitaroApp.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 @main
 struct ScreenshotShitaroApp: App {
+    private let detector = ScreenshotDetector.shared
+
     init() {
         // 起動時にスクリーン録画権限を確認・要求
         PermissionChecker.shared.checkAndRequest()
@@ -16,6 +18,8 @@ struct ScreenshotShitaroApp: App {
 
         Window("Editor", id: "editor") {
             EditorView()
+                // ScreenshotDetector をシングルトンとして環境値で注入
+                .environment(detector)
         }
     }
 }

--- a/screenshot-shitaro/Editor/EditorView.swift
+++ b/screenshot-shitaro/Editor/EditorView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct EditorView: View {
     @Environment(\.undoManager) private var undoManager
+    @Environment(ScreenshotDetector.self) private var detector
 
     @State private var store = AnnotationStore()
     @State private var previewAnnotation: Annotation?
@@ -16,7 +17,7 @@ struct EditorView: View {
     // blur ツール: 事前処理済み CGImage
     @State private var blurredImages: [UUID: CGImage] = [:]
 
-    // ソース画像（Issue #14 マージ後に ScreenshotDetector から注入予定）
+    // ソース画像（ScreenshotDetector.latestScreenshotURL から自動更新）
     @State private var sourceImage: NSImage?
 
     var body: some View {
@@ -37,6 +38,13 @@ struct EditorView: View {
         .onAppear {
             // AppKit 使用: floating ウィンドウ設定（1行のみ）
             NSApp.windows.first { $0.title == "Editor" }?.level = .floating
+        }
+        // 新しいスクリーンショットが検知されたら画像を読み込みキャンバスをリセット
+        .onChange(of: detector.latestScreenshotURL) { _, url in
+            guard let url else { return }
+            sourceImage = NSImage(contentsOf: url)
+            store.removeAll()
+            blurredImages.removeAll()
         }
     }
 


### PR DESCRIPTION
## Summary

- `screenshot_shitaroApp`: `ScreenshotDetector.shared` を `Window` の `.environment()` で EditorView へ注入
- `EditorView`: `@Environment(ScreenshotDetector.self)` で検知器を受け取り、`latestScreenshotURL` の変化を `.onChange` で監視
  - 新 URL が来たら `NSImage(contentsOf:)` で読み込み `sourceImage` に設定
  - `store.removeAll()` + `blurredImages.removeAll()` でキャンバスをリセット（新規スクショに対するクリーン状態を保証）
- `MenuBarView` の `openWindow(id: "editor")` は既存実装のまま継続（変更なし）

## Test plan

- [x] `xcodebuild` ビルド成功確認（Swift 6、エラーなし）
- [ ] ⌘+Shift+3/4/5 でスクショを撮ると自動で Editor ウィンドウが開く
- [ ] EditorView の Canvas に実際のスクリーンショット画像が表示される
- [ ] ぼかしツールで実画像にぼかしが適用される

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)